### PR TITLE
Update mohns rho call and descriptions

### DIFF
--- a/R/retro_wrapper.R
+++ b/R/retro_wrapper.R
@@ -93,8 +93,7 @@ retro_wrapper <- function(mydir,  model_settings) {
       seq_along(runs)[-1],
       function(x) r4ss::SSsummarize(runs[1:x], verbose = FALSE)
     ),
-    endyrvec = mapply(seq,from=endyrvec[1], to= endyrvec[-1]),
-    startyr = endyrvec[-1]
+    endyrvec = mapply(seq,from=endyrvec[1], to= endyrvec[-1])
   )
 
   rhos <- rhosall %>%
@@ -107,7 +106,7 @@ retro_wrapper <- function(mydir,  model_settings) {
       Quantity = gsub("Bratio", "Fraction unfished", Quantity),
       Quantity = gsub("Rec", "Recruitment", Quantity),
       ind = gsub("_[A-Za-z]+$|^[A-Za-z]+$", "", ind),
-      ind = gsub("^$", "Hurtado-Ferro", ind),
+      ind = gsub("^$", "Mohn", ind),
       ind = gsub("WoodHole", "NEFSC", ind),
       ind = gsub("_Hurtado", "", ind),
     ) %>%
@@ -185,7 +184,7 @@ retro_wrapper <- function(mydir,  model_settings) {
         c("spawning stock biomass (\\emph{SSB})", "fraction unfished"),
         "when up to", xfun::numbers_to_words(max(abs(model_settings$retro_yr))),
         "years of data were removed from the base model.",
-        "Mohn's rho (Mohn, 1999) values, as calculated in Hurtado-Ferro et al. (2015), were",
+        "Mohn's rho (Mohn, 1999) values were",
         "recalculated for each peel given the removal of another year of data.",
         "See Table \\ref{tab:RetroMohnsrho} for other derivations of Mohn's rho."
       ),
@@ -213,7 +212,7 @@ retro_wrapper <- function(mydir,  model_settings) {
       label = "RetroMohnsrho",
       escape = FALSE,
       caption = paste(
-        "The average relative bias of retrospective estimates",
+        "The magnitude of retrospective pattern",
         "(Mohn's rho; Mohn, 1999) given the removal of",
         xfun::numbers_to_words(max(abs(model_settings$retro_yr))),
         "years of data for",
@@ -221,9 +220,11 @@ retro_wrapper <- function(mydir,  model_settings) {
         "fraction unfished (Figure \\ref{fig:RetroFractionunfished}),",
         " recruitment, and",
         "spawning stock biomass (\\emph{SSB}; Figure \\ref{fig:RetroSsb}).",
-        "Columns are derivations of Mohn's rho used by the",
-        "Alaska Fisheries Science Center (AFSC),",
-        "suggested by Hurtado-Ferro et al. (2015), and",
+        "Columns are a derivation of Mohn's rho used by the",
+        "Alaska Fisheries Science Center (AFSC)",
+        "suggested by Hurtado-Ferro et al. (2015),",
+        "as originally described in Mohn (1999),",
+        "and a derivation of Mohn's rho (Woods Hole Mohn's rho)",
         "used by the Northeast Fisheries Science Center (NEFSC)."
       )
     ) %>%

--- a/R/retro_wrapper.R
+++ b/R/retro_wrapper.R
@@ -19,7 +19,7 @@
 #' * `mohnsrho.csv` with the following columns:
 #'   * type: the type of Mohn's rho
 #'     * [Mohn (1999)](https://academic.oup.com/icesjms/article/56/4/473/624639),
-#'     * Woods Hole Mohn's rho used by the [Northeast Fisheries Science Center (NEFSC)](https://www.fisheries.noaa.gov/about/northeast-fisheries-science-center), and
+#'     * Woods Hole Mohn's rho [(Legault 2009)](https://archive.nefmc.org/tech/council_mtg_docs/Sept%202009/Herring/Doc%209_Retro%20Working%20Group%20Report.pdf) used by the [Northeast Fisheries Science Center (NEFSC)](https://www.fisheries.noaa.gov/about/northeast-fisheries-science-center), and
 #'     * [Hurtado-Ferro et al. (2015)](https://doi.org/10.1093/icesjms/fsu198) used by the [Alaska Fisheries Science Center (AFSC)](https://www.fisheries.noaa.gov/about/alaska-fisheries-science-center)
 #'   * Quantity: the stock assessment quantity of interest
 #'   * values: the Mohn's rho values
@@ -221,9 +221,9 @@ retro_wrapper <- function(mydir,  model_settings) {
         " recruitment, and",
         "spawning stock biomass (\\emph{SSB}; Figure \\ref{fig:RetroSsb}).",
         "Columns are",
-        "a derivation of Mohn's rho used by the Alaska Fisheries Science Center (AFSC) as suggested by Hurtado-Ferro et al. (2015),",
+        "a derivation of Mohn's rho (Hurtado-Ferro et al. 2015) used by the Alaska Fisheries Science Center (AFSC),",
         "as originally described in Mohn (1999),",
-        "and a derivation of Mohn's rho (Woods Hole Mohn's rho) used by the Northeast Fisheries Science Center (NEFSC)."
+        "and a derivation of Mohn's rho (Woods Hole Mohn's rho; Legault 2009) used by the Northeast Fisheries Science Center (NEFSC)."
       )
     ) %>%
     kableExtra::kable_classic(full_width = FALSE) %>%

--- a/R/retro_wrapper.R
+++ b/R/retro_wrapper.R
@@ -18,9 +18,9 @@
 #'
 #' * `mohnsrho.csv` with the following columns:
 #'   * type: the type of Mohn's rho
-#'     * [Hurtado-Ferro et al. (2015)](https://doi.org/10.1093/icesjms/fsu198),
-#'     * [Northeast Fisheries Science Center (NEFSC)](https://www.fisheries.noaa.gov/about/northeast-fisheries-science-center), and
-#'     * [Alaska Fisheries Science Center (AFSC)](https://www.fisheries.noaa.gov/about/alaska-fisheries-science-center)
+#'     * [Mohn (1999)](https://academic.oup.com/icesjms/article/56/4/473/624639),
+#'     * Woods Hole Mohn's rho used by the [Northeast Fisheries Science Center (NEFSC)](https://www.fisheries.noaa.gov/about/northeast-fisheries-science-center), and
+#'     * [Hurtado-Ferro et al. (2015)](https://doi.org/10.1093/icesjms/fsu198) used by the [Alaska Fisheries Science Center (AFSC)](https://www.fisheries.noaa.gov/about/alaska-fisheries-science-center)
 #'   * Quantity: the stock assessment quantity of interest
 #'   * values: the Mohn's rho values
 #' * A set of figures from [r4ss::SSplotComparisons]

--- a/R/retro_wrapper.R
+++ b/R/retro_wrapper.R
@@ -220,12 +220,10 @@ retro_wrapper <- function(mydir,  model_settings) {
         "fraction unfished (Figure \\ref{fig:RetroFractionunfished}),",
         " recruitment, and",
         "spawning stock biomass (\\emph{SSB}; Figure \\ref{fig:RetroSsb}).",
-        "Columns are a derivation of Mohn's rho used by the",
-        "Alaska Fisheries Science Center (AFSC)",
-        "suggested by Hurtado-Ferro et al. (2015),",
+        "Columns are",
+        "a derivation of Mohn's rho used by the Alaska Fisheries Science Center (AFSC) as suggested by Hurtado-Ferro et al. (2015),",
         "as originally described in Mohn (1999),",
-        "and a derivation of Mohn's rho (Woods Hole Mohn's rho)",
-        "used by the Northeast Fisheries Science Center (NEFSC)."
+        "and a derivation of Mohn's rho (Woods Hole Mohn's rho) used by the Northeast Fisheries Science Center (NEFSC)."
       )
     ) %>%
     kableExtra::kable_classic(full_width = FALSE) %>%


### PR DESCRIPTION
With commit r4ss/r4ss@7c3d3fb9fd449a340111470793b83ba83a0de546, the call to SS_mohnsrho here needs to be updated so that the calculation of Woods-Hole mohn's rho is correct. I removed the startyr input because the new default is to start from the start year of the reference model. 

Some of the descriptions of the types of Mohn's rho that are output were confusing as well as the description of the function. I updated these statements to better match with the descriptions in SS_mohnsrho, where the AFSC and Hurtado-Ferro values are the same, the base output is the original Mohn's rho, and I made the NEFSC reference more clear that it’s the Woods-Hole mohn’s rho. 


