### PR TITLE
Fix various plotting issues

### DIFF
--- a/R/plot_retro.R
+++ b/R/plot_retro.R
@@ -128,11 +128,7 @@ plot_retro <- function(mydir, model_settings, output) {
     )
   )
 
-  label <- ifelse(
-    retroSummary[["SpawnOutputUnits"]][1] == "biomass",
-    "Spawning Biomass",
-    "Spawning Output"
-  )
+  label <- retroSummary[["SpawnOutputLabels"]][1]
   n <- ncol(retroSummary[["SpawnBio"]]) - 2
   years <- retroSummary[["startyrs"]][1]:retroSummary[["endyrs"]][1] + 1
   denom <- paste0("model", 1:n)

--- a/R/profile_plot.R
+++ b/R/profile_plot.R
@@ -219,8 +219,8 @@ plot_profile <- function(mydir, rep, para, profilesummary) {
   # parameter vs. SB0
   plot(x, sb0,
     type = "l", lwd = 2, xlab = label,
-    ylab = ifelse(profilesummary[["SpawnOutputUnits"]][1] == "numbers",
-      expression(SO[0]), expression(SB[0])
+    ylab = ifelse(profilesummary[["SpawnOutputUnits"]][1] == "biomass",
+      expression(SB[0]), expression(SO[0])
     ), ylim = c(0, max(sb0))
   )
   points(est, sb0_est, pch = 21, col = "black", bg = "blue", cex = 1.5)
@@ -228,8 +228,8 @@ plot_profile <- function(mydir, rep, para, profilesummary) {
   # parameter vs. SBfinal
   plot(x, sbf,
     type = "l", lwd = 2, xlab = label,
-    ylab = ifelse(profilesummary[["SpawnOutputUnits"]][1] == "numbers",
-      expression(SO[final]), expression(SB[final])
+    ylab = ifelse(profilesummary[["SpawnOutputUnits"]][1] == "biomass",
+      expression(SB[final]), expression(SO[final])
     ), ylim = c(0, max(sbf))
   )
   points(est, sbf_est, pch = 21, col = "black", bg = "blue", cex = 1.5)

--- a/R/profile_plot.R
+++ b/R/profile_plot.R
@@ -59,10 +59,10 @@ plot_profile <- function(mydir, rep, para, profilesummary) {
   if (tot_plot == 1) {
     panel <- c(2, 1)
   }
-  if (tot_plot != 1 & tot_plot <= 3) {
-    panel <- c(3, 1)
-  }
-  if (tot_plot >= 3) {
+  #if (tot_plot != 1 & tot_plot <= 3) {
+  #  panel <- c(3, 1)
+  #}
+  if (tot_plot >= 2) {
     panel <- c(2, 2)
   }
   if (tot_plot >= 4) {
@@ -89,44 +89,81 @@ plot_profile <- function(mydir, rep, para, profilesummary) {
     ymax2 <- 5
   }
 
-  pngfun(wd = mydir, file = paste0("piner_panel_", para, ".png"), h = 7, w = 7)
+  adj_size <- ifelse(length(profilesummary$FleetNames) < 6, 7, 10)
+  pngfun(wd = mydir, file = paste0("piner_panel_", para, ".png"), h = adj_size, w = adj_size)
   on.exit(grDevices::dev.off(), add = TRUE)
   graphics::par(mfrow = panel)
   r4ss::SSplotProfile(
-    summaryoutput = profilesummary, main = "Changes in total likelihood", profile.string = get,
-    profile.label = label, ymax = ymax1, exact = exact
+    summaryoutput = profilesummary,
+    main = "Changes in total likelihood",
+    profile.string = get,
+    profile.label = label,
+    ymax = ymax1,
+    exact = exact
   )
   graphics::abline(h = 1.92, lty = 3, col = "red")
 
   if ("Length_like" %in% use) {
     r4ss::PinerPlot(
-      summaryoutput = profilesummary, plot = TRUE, print = FALSE, component = "Length_like",
-      main = "Length-composition likelihoods", profile.string = get, profile.label = label,
-      exact = exact, ylab = "Change in -log-likelihood", legendloc = "topright", ymax = ymax2
+      summaryoutput = profilesummary,
+      plot = TRUE,
+      print = FALSE,
+      component = "Length_like",
+      main = "Length-composition likelihoods",
+      profile.string = get,
+      profile.label = label,
+      exact = exact,
+      ylab = "Change in -log-likelihood",
+      legendloc = "topright",
+      ymax = ymax2
     )
   }
 
   if ("Age_like" %in% use) {
     r4ss::PinerPlot(
-      summaryoutput = profilesummary, plot = TRUE, print = FALSE, component = "Age_like",
-      main = "Age-composition likelihoods", profile.string = get, profile.label = label,
-      exact = exact, ylab = "Change in -log-likelihood", legendloc = "topright", ymax = ymax2
+      summaryoutput = profilesummary,
+      plot = TRUE,
+      print = FALSE,
+      component = "Age_like",
+      main = "Age-composition likelihoods",
+      profile.string = get,
+      profile.label = label,
+      exact = exact,
+      ylab = "Change in -log-likelihood",
+      legendloc = "topright",
+      ymax = ymax2
     )
   }
 
   if ("Surv_like" %in% use) {
     r4ss::PinerPlot(
-      summaryoutput = profilesummary, plot = TRUE, print = FALSE, component = "Surv_like",
-      main = "Survey likelihoods", profile.string = get, profile.label = label,
-      exact = exact, ylab = "Change in -log-likelihood", legendloc = "topright", ymax = ymax2
+      summaryoutput = profilesummary,
+      plot = TRUE,
+      print = FALSE,
+      component = "Surv_like",
+      main = "Survey likelihoods",
+      profile.string = get,
+      profile.label = label,
+      exact = exact,
+      ylab = "Change in -log-likelihood",
+      legendloc = "topright",
+      ymax = ymax2
     )
   }
 
   if ("Init_equ_like" %in% use) {
     r4ss::PinerPlot(
-      summaryoutput = profilesummary, plot = TRUE, print = FALSE, component = "Init_equ_like",
-      main = "Initial equilibrium likelihoods", profile.string = get, profile.label = label,
-      exact = exact, ylab = "Change in -log-likelihood", legendloc = "topright", ymax = ymax2
+      summaryoutput = profilesummary,
+      plot = TRUE,
+      print = FALSE,
+      component = "Init_equ_like",
+      main = "Initial equilibrium likelihoods",
+      profile.string = get,
+      profile.label = label,
+      exact = exact,
+      ylab = "Change in -log-likelihood",
+      legendloc = "topright",
+      ymax = ymax2
     )
   }
 

--- a/R/profile_plot.R
+++ b/R/profile_plot.R
@@ -240,7 +240,8 @@ plot_profile <- function(mydir, rep, para, profilesummary) {
     para == "SR_LN(R0)" ~ "log(R0)",
     para %in% c("NatM_uniform_Fem_GP_1", "NatM_p_1_Fem_GP_1", "NatM_break_1_Fem_GP_1") ~ "M (f)",
     para %in% c("NatM_uniform_Mal_GP_1", "NatM_p_1_Mal_GP_1", "NatM_break_1_Mal_GP_1") ~ "M (m)",
-    para == "SR_BH_steep" ~ "h"
+    para == "SR_BH_steep" ~ "h",
+    .default = para
   )
 
   r4ss::SSplotComparisons(

--- a/R/profile_plot.R
+++ b/R/profile_plot.R
@@ -89,7 +89,7 @@ plot_profile <- function(mydir, rep, para, profilesummary) {
     ymax2 <- 5
   }
 
-  adj_size <- ifelse(length(profilesummary$FleetNames) < 6, 7, 10)
+  adj_size <- ifelse(length(profilesummary$FleetNames[[1]]) < 6, 7, 10)
   pngfun(wd = mydir, file = paste0("piner_panel_", para, ".png"), h = adj_size, w = adj_size)
   on.exit(grDevices::dev.off(), add = TRUE)
   graphics::par(mfrow = panel)

--- a/R/rerun_profile_vals.R
+++ b/R/rerun_profile_vals.R
@@ -100,8 +100,10 @@ rerun_profile_vals <- function(mydir,
   file.copy(file.path(profile_dir, data_file_nm), temp_dir)
   file.copy(file.path(profile_dir, "starter.ss_new"), temp_dir)
   file.copy(file.path(profile_dir, "forecast.ss_new"), temp_dir)
+  file.copy(file.path(profile_dir, "wtatage.ss_new"), temp_dir)
   file.rename(file.path(temp_dir, "starter.ss_new"), file.path(temp_dir, "starter.ss"))
   file.rename(file.path(temp_dir, "forecast.ss_new"), file.path(temp_dir, "forecast.ss"))
+  file.rename(file.path(temp_dir, "wtatage.ss_new"), file.path(temp_dir, "wtatage.ss"))
 
   # Use the SS_parlines function to ensure that the input parameter can be found
   check_para <- r4ss::SS_parlines(
@@ -129,6 +131,7 @@ rerun_profile_vals <- function(mydir,
   starter[["init_values_src"]] <- model_settings[["init_values_src"]]
   # make sure the prior likelihood is calculated for non-estimated quantities
   starter[["prior_like"]] <- 1
+  starter[["ctlfile"]] <- model_settings[["newctlfile"]]
   r4ss::SS_writestarter(
     starter,
     dir = temp_dir,

--- a/R/rerun_profile_vals.R
+++ b/R/rerun_profile_vals.R
@@ -198,11 +198,11 @@ rerun_profile_vals <- function(mydir,
       )
     }
     file.rename(
-      file.path(temp_dir, "ss.par"),
-      file.path(temp_dir, paste0("ss.par_", i, ".sso"))
+      file.path(temp_dir, "ss3.par"),
+      file.path(temp_dir, paste0("ss3.par_", i, ".sso"))
     )
     file.copy(
-      file.path(temp_dir, paste0("ss.par_", i, ".sso")),
+      file.path(temp_dir, paste0("ss3.par_", i, ".sso")),
       profile_dir,
       overwrite = TRUE
     )

--- a/R/run_mcmc_diagnostics.R
+++ b/R/run_mcmc_diagnostics.R
@@ -110,8 +110,10 @@ run_mcmc_diagnostics <- function(
     iter = iter,
     chains = chains
   )
-  # This thin rate will lead to run time of ~60 mins below
-  thin60min <- floor((60 * 60 * hour) / mean(fit$time.total))
+  # The default thin rate will lead to run time of ~60 mins below
+  duration <- hour * 60
+  thin60min <- floor((60 * duration) / mean(fit$time.total))
+
   # ------------------------------------------------------------
   # Task 1: Run and demonstrate MCMC convergence diagnostics.
   chains <- parallel::detectCores() - 3
@@ -135,7 +137,7 @@ run_mcmc_diagnostics <- function(
     warmup = floor(iter * 0.25),
     chains = chains,
     thin = thin,
-    duration = 60
+    duration = duration
   )
   # Good idea to save the output, I recommend RDS format.
   saveRDS(fit, file = file.path(p, "fits", "mcmc.RDS"))

--- a/R/run_mcmc_diagnostics.R
+++ b/R/run_mcmc_diagnostics.R
@@ -16,6 +16,11 @@
 #' @param iter A numeric value for the number of MCMC draws to do. Default is
 #'   2000.
 #' @param chains A numeric value for the number of chains to run. Default is 2.
+#' @param hour A numeric value that controls the thin rate.  The thin rate is
+#'   calculated based upon the length of time to run the model to allow the
+#'   function to run in  a pre-specified amount of time. For some models, one
+#'   may want to run this function for longer allowing a greater thin rate.
+#'   The default is 1 hour.
 #' @param interactive A logical, where `TRUE` will run
 #'   [adnuts::launch_shinyadmb()]. The default is `FALSE`.
 #' @param verbose A logical, specifying if information should be printed
@@ -33,6 +38,7 @@ run_mcmc_diagnostics <- function(
     extension = ".exe",
     iter = 2000,
     chains = 2,
+    hour = 1,
     interactive = FALSE,
     verbose = FALSE) {
   # Set up and test model for running. This requires
@@ -105,7 +111,7 @@ run_mcmc_diagnostics <- function(
     chains = chains
   )
   # This thin rate will lead to run time of ~60 mins below
-  thin60min <- floor((60 * 60) / mean(fit$time.total))
+  thin60min <- floor((60 * 60 * hour) / mean(fit$time.total))
   # ------------------------------------------------------------
   # Task 1: Run and demonstrate MCMC convergence diagnostics.
   chains <- parallel::detectCores() - 3

--- a/R/run_mcmc_diagnostics.R
+++ b/R/run_mcmc_diagnostics.R
@@ -123,13 +123,14 @@ run_mcmc_diagnostics <- function(
   duration <- hour * 60
   if (is.null(thin)) {
     thin <- floor((60 * duration) / mean(fit$time.total))
+  } else {
+    thin <- thin
   }
+  iter_adj <- iter * thin
 
   # ------------------------------------------------------------
   # Task 1: Run and demonstrate MCMC convergence diagnostics.
-  chains <- parallel::detectCores() -
-  iter_adj <- iter * thin
-
+  chains <- parallel::detectCores() - 3
   # The below call was added to try to fix the test for a linux machine
   # but is did not fix the issue and caused an error for regular use.
   # Potential fix options: https://stackoverflow.com/questions/46503873/r-parallelisation-error-checkclustercl-not-a-valid-cluster

--- a/R/run_mcmc_diagnostics.R
+++ b/R/run_mcmc_diagnostics.R
@@ -123,7 +123,7 @@ run_mcmc_diagnostics <- function(
   # convergence diagnostics passed (ESS>200 & Rhat<1.1).
   # printed to screen live!!
   thin <- thin60min # change this as needed
-  iter <- iter * thin
+  iter_adj <- iter * thin
   # Duration argument will stop after 40 minutes, only used
   # for the workshop to keep things organized
   # The below call was added to try to fix the test for a linux machine
@@ -133,8 +133,8 @@ run_mcmc_diagnostics <- function(
   fit <- adnuts::sample_rwm(
     model = model,
     path = p,
-    iter = iter,
-    warmup = floor(iter * 0.25),
+    iter = iter_adj,
+    warmup = floor(iter_adj * 0.25),
     chains = chains,
     thin = thin,
     duration = duration

--- a/R/run_mcmc_diagnostics.R
+++ b/R/run_mcmc_diagnostics.R
@@ -21,6 +21,9 @@
 #'   function to run in  a pre-specified amount of time. For some models, one
 #'   may want to run this function for longer allowing a greater thin rate.
 #'   The default is 1 hour.
+#' @param thin The thin level for samples.  The default is NULL where the code will
+#'   determine a thin rate based on the time to the run the model and the number of
+#'   iterations, `iter`.
 #' @param interactive A logical, where `TRUE` will run
 #'   [adnuts::launch_shinyadmb()]. The default is `FALSE`.
 #' @param verbose A logical, specifying if information should be printed
@@ -39,6 +42,7 @@ run_mcmc_diagnostics <- function(
     iter = 2000,
     chains = 2,
     hour = 1,
+    thin = NULL,
     interactive = FALSE,
     verbose = FALSE) {
   # Set up and test model for running. This requires
@@ -110,22 +114,22 @@ run_mcmc_diagnostics <- function(
     iter = iter,
     chains = chains
   )
-  # The default thin rate will lead to run time of ~60 mins below
-  duration <- hour * 60
-  thin60min <- floor((60 * duration) / mean(fit$time.total))
-
-  # ------------------------------------------------------------
-  # Task 1: Run and demonstrate MCMC convergence diagnostics.
-  chains <- parallel::detectCores() - 3
-
   # I recommend using 1000-2000 iterations, with first 10-25%
   # warmup. Start with thin=1, then increase thin rate until
   # convergence diagnostics passed (ESS>200 & Rhat<1.1).
   # printed to screen live!!
-  thin <- thin60min # change this as needed
+
+  # The default thin rate will lead to run time of ~60 mins below
+  duration <- hour * 60
+  if (is.null(thin)) {
+    thin <- floor((60 * duration) / mean(fit$time.total))
+  }
+
+  # ------------------------------------------------------------
+  # Task 1: Run and demonstrate MCMC convergence diagnostics.
+  chains <- parallel::detectCores() -
   iter_adj <- iter * thin
-  # Duration argument will stop after 40 minutes, only used
-  # for the workshop to keep things organized
+
   # The below call was added to try to fix the test for a linux machine
   # but is did not fix the issue and caused an error for regular use.
   # Potential fix options: https://stackoverflow.com/questions/46503873/r-parallelisation-error-checkclustercl-not-a-valid-cluster

--- a/R/run_profile.R
+++ b/R/run_profile.R
@@ -174,8 +174,8 @@ run_profile <- function(mydir, model_settings, para) {
   }
 
   vec <- c(low, high)
-  if (est %in% vec) {
-    vec <- vec[!vec == est]
+  if (length(vec) != length(unique(vec))) {
+    vec <- unique(vec)
   }
   num <- sort(vec, index.return = TRUE)[["ix"]]
 

--- a/man/run_mcmc_diagnostics.Rd
+++ b/man/run_mcmc_diagnostics.Rd
@@ -10,6 +10,7 @@ run_mcmc_diagnostics(
   extension = ".exe",
   iter = 2000,
   chains = 2,
+  hour = 1,
   interactive = FALSE,
   verbose = FALSE
 )
@@ -35,6 +36,12 @@ machines.}
 2000.}
 
 \item{chains}{A numeric value for the number of chains to run. Default is 2.}
+
+\item{hour}{A numeric value that controls the thin rate.  The thin rate is
+calculated based upon the length of time to run the model to allow the
+function to run in  a pre-specified amount of time. For some models, one
+may want to run this function for longer allowing a greater thin rate.
+The default is 1 hour.}
 
 \item{interactive}{A logical, where \code{TRUE} will run
 \code{\link[adnuts:launch_shinyadmb]{adnuts::launch_shinyadmb()}}. The default is \code{FALSE}.}


### PR DESCRIPTION
1. Fix SB0 and fraction unfished labels for non-standard profile parameters.
2. Fix par name.
3. Add switch for png size based on the number of fleets.
4. Fix to include the base model parameter in the profile figures.
5. Fix spawning units check for models that use weight-at-age.
6. Add additional controls from MCMC runs.